### PR TITLE
Extend HeaderArg to support advanced HTTP Header handling

### DIFF
--- a/servant-jquery.cabal
+++ b/servant-jquery.cabal
@@ -31,7 +31,11 @@ flag example
 library
   exposed-modules:     Servant.JQuery
   other-modules:       Servant.JQuery.Internal
-  build-depends:       base >=4.5 && <5, servant >= 0.2.1, lens >= 4, MissingH
+  build-depends:       base >=4.5 && <5
+                     , servant >= 0.2.1
+                     , lens >= 4
+                     , MissingH
+                     , charset
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/servant-jquery.cabal
+++ b/servant-jquery.cabal
@@ -65,6 +65,7 @@ test-suite spec
   main-is:           Spec.hs
   build-depends:
       base == 4.*
+    , lens
     , servant-jquery
     , servant
     , hspec >= 2.0

--- a/servant-jquery.cabal
+++ b/servant-jquery.cabal
@@ -32,10 +32,10 @@ library
   exposed-modules:     Servant.JQuery
   other-modules:       Servant.JQuery.Internal
   build-depends:       base >=4.5 && <5
-                     , servant >= 0.2.1
-                     , lens >= 4
-                     , MissingH
                      , charset
+                     , lens >= 4
+                     , servant >= 0.2.1
+                     , split
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/servant-jquery.cabal
+++ b/servant-jquery.cabal
@@ -35,7 +35,7 @@ library
                      , charset
                      , lens >= 4
                      , servant >= 0.2.1
-                     , split
+                     , text
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/servant-jquery.cabal
+++ b/servant-jquery.cabal
@@ -31,7 +31,7 @@ flag example
 library
   exposed-modules:     Servant.JQuery
   other-modules:       Servant.JQuery.Internal
-  build-depends:       base >=4.5 && <5, servant >= 0.2.1, lens >= 4
+  build-depends:       base >=4.5 && <5, servant >= 0.2.1, lens >= 4, MissingH
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -68,5 +68,6 @@ test-suite spec
     , servant-jquery
     , servant
     , hspec >= 2.0
+    , hspec-expectations
     , language-ecmascript == 0.16.*
   default-language: Haskell2010

--- a/src/Servant/JQuery.hs
+++ b/src/Servant/JQuery.hs
@@ -44,7 +44,7 @@ generateJS req = "\n" <>
         args = captures
             ++ map (view argName) queryparams
             ++ body
-            ++ map ((<>) "header" . headerArgName) hs
+            ++ map (toValidFunctionName . (<>) "header" . headerArgName) hs
             ++ ["onSuccess", "onError"]
         
         captures = map captureArg
@@ -70,7 +70,9 @@ generateJS req = "\n" <>
             else "\n    , headers: { " ++ headersStr ++ " }\n"
 
           where headersStr = intercalate ", " $ map headerStr hs
-                headerStr header = "\"" ++ headerArgName header ++ "\": " ++ show header
+                headerStr header = "\"" ++
+                  headerArgName header ++
+                  "\": " ++ show header
 
         fname = req ^. funcName
         method = req ^. reqMethod

--- a/src/Servant/JQuery.hs
+++ b/src/Servant/JQuery.hs
@@ -44,7 +44,7 @@ generateJS req = "\n" <>
         args = captures
             ++ map (view argName) queryparams
             ++ body
-            ++ map ("header"++) hs
+            ++ map ((<>) "header" . headerArgName) hs
             ++ ["onSuccess", "onError"]
         
         captures = map captureArg
@@ -67,10 +67,10 @@ generateJS req = "\n" <>
         reqheaders =
           if null hs
             then ""
-            else "\n    , headers: { " ++ headersStr ++ " } }\n"
+            else "\n    , headers: { " ++ headersStr ++ " }\n"
 
           where headersStr = intercalate ", " $ map headerStr hs
-                headerStr hname = "\"" ++ hname ++ "\": header" ++ hname
+                headerStr header = "\"" ++ headerArgName header ++ "\": " ++ show header
 
         fname = req ^. funcName
         method = req ^. reqMethod

--- a/src/Servant/JQuery/Internal.hs
+++ b/src/Servant/JQuery/Internal.hs
@@ -12,9 +12,9 @@ import Data.Char (toLower)
 import qualified Data.CharSet as Set
 import qualified Data.CharSet.Unicode.Category as Set
 import Data.List
-import Data.List.Split
 import Data.Monoid
 import Data.Proxy
+import qualified Data.Text as T
 import GHC.TypeLits
 import Servant.API
 
@@ -77,8 +77,10 @@ instance Show HeaderArg where
         pv = toValidFunctionName ("header" <> n)
         pn = "{" <> n <> "}"
         rp = replace pn "" p
-        -- Nicked from Data.String.Utils, works on lists
-        replace old new l = intercalate new . splitOn old $ l
+        -- Use replace method from Data.Text
+        replace old new = T.unpack .
+            T.replace (T.pack old) (T.pack new) .
+            T.pack
 
 -- | Attempts to reduce the function name provided to that allowed by JS.
 -- https://mathiasbynens.be/notes/javascript-identifiers

--- a/src/Servant/JQuery/Internal.hs
+++ b/src/Servant/JQuery/Internal.hs
@@ -72,7 +72,7 @@ instance Show HeaderArg where
         | otherwise         = p
       where
         pv = "header" <> n
-        pn = "{header" <> n <> "}"
+        pn = "{" <> n <> "}"
         rp = replace pn "" p
 
 data Url = Url

--- a/src/Servant/JQuery/Internal.hs
+++ b/src/Servant/JQuery/Internal.hs
@@ -12,9 +12,9 @@ import Data.Char (toLower)
 import qualified Data.CharSet as Set
 import qualified Data.CharSet.Unicode.Category as Set
 import Data.List
+import Data.List.Split
 import Data.Monoid
 import Data.Proxy
-import Data.String.Utils
 import GHC.TypeLits
 import Servant.API
 
@@ -68,14 +68,17 @@ data HeaderArg = HeaderArg
 instance Show HeaderArg where
     show (HeaderArg n)          = toValidFunctionName ("header" <> n)
     show (ReplaceHeaderArg n p)
-        | pn `startswith` p = pv <> " + \"" <> rp <> "\""
-        | pn `endswith` p   = "\"" <> rp <> "\" + " <> pv
-        | pn `isInfixOf` p  = "\"" <> (replace pn ("\" + " <> pv <> " + \"") p) <> "\""
+        | pn `isPrefixOf` p = pv <> " + \"" <> rp <> "\""
+        | pn `isSuffixOf` p = "\"" <> rp <> "\" + " <> pv
+        | pn `isInfixOf` p  = "\"" <> (replace pn ("\" + " <> pv <> " + \"") p)
+                                   <> "\""
         | otherwise         = p
       where
         pv = toValidFunctionName ("header" <> n)
         pn = "{" <> n <> "}"
         rp = replace pn "" p
+        -- Nicked from Data.String.Utils, works on lists
+        replace old new l = intercalate new . splitOn old $ l
 
 -- | Attempts to reduce the function name provided to that allowed by JS.
 -- https://mathiasbynens.be/notes/javascript-identifiers

--- a/test/Servant/JQuerySpec.hs
+++ b/test/Servant/JQuerySpec.hs
@@ -33,6 +33,9 @@ type CustomAuthAPI = "something" :> Authorization "Basic" String
 type CustomHeaderAPI = "something" :> MyLovelyHorse String
                                    :> Get Int
 
+type CustomHeaderAPI2 = "something" :> WhatsForDinner String
+                                    :> Get Int
+
 headerHandlingProxy :: Proxy HeaderHandlingAPI
 headerHandlingProxy = Proxy
 
@@ -41,6 +44,9 @@ customAuthProxy = Proxy
 
 customHeaderProxy :: Proxy CustomHeaderAPI
 customHeaderProxy = Proxy
+
+customHeaderProxy2 :: Proxy CustomHeaderAPI2
+customHeaderProxy2 = Proxy
 
 spec :: Spec
 spec = describe "Servant.JQuery"
@@ -79,3 +85,10 @@ generateJSSpec = describe "generateJS" $ do
         parseFromString jsText `shouldSatisfy` isRight
         jsText `shouldContain` "headerXMyLovelyHorse"
         jsText `shouldContain` "headers: { \"X-MyLovelyHorse\": \"I am good friends with \" + headerXMyLovelyHorse }\n"
+
+    it "should handle complex, custom HTTP headers (template replacement)" $ do
+        let jsText = generateJS $ jquery customHeaderProxy2
+        print jsText
+        parseFromString jsText `shouldSatisfy` isRight
+        jsText `shouldContain` "headerXWhatsForDinner"
+        jsText `shouldContain` "headers: { \"X-WhatsForDinner\": \"I would like \" + headerXWhatsForDinner + \" with a cherry on top.\" }\n"

--- a/test/Servant/JQuerySpec.hs
+++ b/test/Servant/JQuerySpec.hs
@@ -14,6 +14,7 @@ import Test.Hspec
 
 import Servant.API
 import Servant.JQuery
+import Servant.JQuerySpec.CustomHeaders
 
 type TestAPI = [sitemap|
 POST    /simple                  String -> Bool
@@ -26,8 +27,14 @@ type TopLevelRawAPI = "something" :> Get Int
 type HeaderHandlingAPI = "something" :> Header "Foo" String
                                      :> Get Int
 
+type CustomAuthAPI = "something" :> Authorization "Basic" String
+                                 :> Get Int
+
 headerHandlingProxy :: Proxy HeaderHandlingAPI
 headerHandlingProxy = Proxy
+
+customAuthProxy :: Proxy CustomAuthAPI
+customAuthProxy = Proxy
 
 spec :: Spec
 spec = describe "Servant.JQuery"
@@ -52,4 +59,11 @@ generateJSSpec = describe "generateJS" $ do
         parseFromString jsText `shouldSatisfy` isRight
         jsText `shouldContain` "headerFoo"
         jsText `shouldContain` "headers: { \"Foo\": headerFoo }\n"
+
+    it "should handle complex HTTP headers" $ do
+        let jsText = generateJS $ jquery customAuthProxy
+        print jsText
+        parseFromString jsText `shouldSatisfy` isRight
+        jsText `shouldContain` "headerAuthorization"
+        jsText `shouldContain` "headers: { \"Authorization\": \"Basic \" + headerAuthorization }\n"
 

--- a/test/Servant/JQuerySpec.hs
+++ b/test/Servant/JQuerySpec.hs
@@ -30,11 +30,17 @@ type HeaderHandlingAPI = "something" :> Header "Foo" String
 type CustomAuthAPI = "something" :> Authorization "Basic" String
                                  :> Get Int
 
+type CustomHeaderAPI = "something" :> MyLovelyHorse String
+                                   :> Get Int
+
 headerHandlingProxy :: Proxy HeaderHandlingAPI
 headerHandlingProxy = Proxy
 
 customAuthProxy :: Proxy CustomAuthAPI
 customAuthProxy = Proxy
+
+customHeaderProxy :: Proxy CustomHeaderAPI
+customHeaderProxy = Proxy
 
 spec :: Spec
 spec = describe "Servant.JQuery"
@@ -67,3 +73,9 @@ generateJSSpec = describe "generateJS" $ do
         jsText `shouldContain` "headerAuthorization"
         jsText `shouldContain` "headers: { \"Authorization\": \"Basic \" + headerAuthorization }\n"
 
+    it "should handle complex, custom HTTP headers" $ do
+        let jsText = generateJS $ jquery customHeaderProxy
+        print jsText
+        parseFromString jsText `shouldSatisfy` isRight
+        jsText `shouldContain` "headerXMyLovelyHorse"
+        jsText `shouldContain` "headers: { \"X-MyLovelyHorse\": \"I am good friends with \" + headerXMyLovelyHorse }\n"

--- a/test/Servant/JQuerySpec/CustomHeaders.hs
+++ b/test/Servant/JQuerySpec/CustomHeaders.hs
@@ -21,11 +21,23 @@ import Servant.JQuery
 data Authorization (sym :: Symbol) a
 
 instance (KnownSymbol sym, HasJQ sublayout)
-	=> HasJQ (Authorization sym a :> sublayout) where
+    => HasJQ (Authorization sym a :> sublayout) where
     type JQ (Authorization sym a :> sublayout) = JQ sublayout
 
     jqueryFor Proxy req = jqueryFor (Proxy :: Proxy sublayout) $
         req & reqHeaders <>~ [ ReplaceHeaderArg "Authorization" $
-        					   tokenType (symbolVal (Proxy :: Proxy sym)) ]
+                               tokenType (symbolVal (Proxy :: Proxy sym)) ]
       where
-      	tokenType t = t <> " {Authorization}"
+        tokenType t = t <> " {Authorization}"
+
+-- | This is a combinator that fetches an X-MyLovelyHorse header.
+data MyLovelyHorse a
+
+instance (HasJQ sublayout)
+    => HasJQ (MyLovelyHorse a :> sublayout) where
+    type JQ (MyLovelyHorse a :> sublayout) = JQ sublayout
+
+    jqueryFor Proxy req = jqueryFor (Proxy :: Proxy sublayout) $
+        req & reqHeaders <>~ [ ReplaceHeaderArg "X-MyLovelyHorse" tpl ]
+      where
+        tpl = "I am good friends with {X-MyLovelyHorse}"

--- a/test/Servant/JQuerySpec/CustomHeaders.hs
+++ b/test/Servant/JQuerySpec/CustomHeaders.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
+
+module Servant.JQuerySpec.CustomHeaders where
+
+import Control.Lens
+import Data.Monoid
+import Data.Proxy
+import GHC.TypeLits
+import Servant.API
+import Servant.JQuery
+
+-- | This is a hypothetical combinator that fetches an Authorization header.
+-- The symbol in the header denotes what kind of authentication we are
+-- using -- Basic, Digest, whatever.
+data Authorization (sym :: Symbol) a
+
+instance (KnownSymbol sym, HasJQ sublayout)
+	=> HasJQ (Authorization sym a :> sublayout) where
+    type JQ (Authorization sym a :> sublayout) = JQ sublayout
+
+    jqueryFor Proxy req = jqueryFor (Proxy :: Proxy sublayout) $
+        req & reqHeaders <>~ [ ReplaceHeaderArg "Authorization" $
+        					   tokenType (symbolVal (Proxy :: Proxy sym)) ]
+      where
+      	tokenType t = t <> " {Authorization}"

--- a/test/Servant/JQuerySpec/CustomHeaders.hs
+++ b/test/Servant/JQuerySpec/CustomHeaders.hs
@@ -41,3 +41,15 @@ instance (HasJQ sublayout)
         req & reqHeaders <>~ [ ReplaceHeaderArg "X-MyLovelyHorse" tpl ]
       where
         tpl = "I am good friends with {X-MyLovelyHorse}"
+
+-- | This is a combinator that fetches an X-WhatsForDinner header.
+data WhatsForDinner a
+
+instance (HasJQ sublayout)
+    => HasJQ (WhatsForDinner a :> sublayout) where
+    type JQ (WhatsForDinner a :> sublayout) = JQ sublayout
+
+    jqueryFor Proxy req = jqueryFor (Proxy :: Proxy sublayout) $
+        req & reqHeaders <>~ [ ReplaceHeaderArg "X-WhatsForDinner" tpl ]
+      where
+        tpl = "I would like {X-WhatsForDinner} with a cherry on top."


### PR DESCRIPTION
I'd like to propose some significant changes to the way that the HeaderArg type is handled in servant-jquery to allow extensions to the way they work.

Specifically, in my changes, the `HeaderArg` type gets turned into a data type, and the original type is denoted as a `HeaderArg String`. I've added a variation called `ReplaceHeaderArg String String`, which takes the first value as the header name, and uses it to replace a value in the second string, which is used to render the final Javascript.

For example, you could define `ReplaceHeaderArg "X-MyLovelyHorse" "I am friends with {X-MyLovelyHorse}", and it would compose the AJAX function like so:
```javascript
function getthings(headerXMyLovelyHorse, onSuccess, onError)
{
  $.ajax(
    {
      url: "/things"
    , success: onSuccess
    , headers: {
      "X-MyLovelyHorse": "I am friends with " + headerXMyLovelyHorse
    }
    , error: onError
    , type: "json"
    });
}
```

This allows us to be confident that we are sending a properly composed X-MyLovelyHorse header.

More practically, I'd like to use this to compose with Authorization headers, and specifying the desired type of Authorization set as a symbol in the Authorization data type. The changes to the tests demonstrate how I intend to do this.