### PR TITLE
WIP - do not merge - Customised function rendering

### DIFF
--- a/servant-jquery.cabal
+++ b/servant-jquery.cabal
@@ -30,7 +30,9 @@ flag example
 
 library
   exposed-modules:     Servant.JQuery
-  other-modules:       Servant.JQuery.Internal
+  other-modules:       Servant.JQuery.Functions
+                     , Servant.JQuery.Internal
+                     , Servant.JQuery.Types
   build-depends:       base >=4.5 && <5, servant >= 0.2.1, lens >= 4
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/Servant/JQuery.hs
+++ b/src/Servant/JQuery.hs
@@ -14,6 +14,7 @@ module Servant.JQuery
   , generateJS
   , generateJSWith
   , printJS
+  , printJSWith
   , module Servant.JQuery.Internal
   , Settings(..)
   , FunctionFormat(..)
@@ -28,16 +29,33 @@ import Servant.JQuery.Functions
 import Servant.JQuery.Internal
 import Servant.JQuery.Types
 
-jquery :: HasJQ layout => Proxy layout -> JQ layout
+-- | Compiles a Servant API type represented by a Proxy into a series of
+-- values joined by the
+-- @
+-- :\<|\>
+-- @
+-- combinator provided by Servant API, each representing an API endpoint.
+-- These can then be used to render each API endpoint out as a Javascript
+-- function that, when invoked, sends a request to this endpoint.
+jquery
+    :: HasJQ layout
+    => Proxy layout -- ^ Proxy for a Servant API type
+    -> JQ layout -- ^ A JQ layout object containing a series of AjaxReq
+                 -- values separated by
+                 -- @
+                 -- :\<|\>
+                 -- @
 jquery p = jqueryFor p defReq
 
--- | JS code generation with default settings
+-- | Renders a jQuery AJAX request definition into Javascript code,
+-- using default settings.
 generateJS
     :: AjaxReq -- ^ AJAX request definition
     -> String  -- ^ Rendered Javascript
 generateJS = generateJSWith defaultSettings
 
--- | JS code generation with custom settings
+-- | Renders a jQuery AJAX request definition into Javascript code,
+-- using custom settings provided as an argument.
 generateJSWith
     :: Settings -- ^ Servant.JQuery Settings
     -> AjaxReq -- ^ AJAX request
@@ -100,5 +118,17 @@ generateJSWith settings req = renderFunctionWrap (_functionFormat settings)
                       then ""
                       else " + '?" ++ jsParams queryparams
 
-printJS :: AjaxReq -> IO ()
+-- | Renders a jQuery AJAX request definition into Javascript code,
+-- using default settings, and prints it to STDOUT.
+printJS
+    :: AjaxReq -- ^ AJAX request definition
+    -> IO ()
 printJS = putStrLn . generateJS
+
+-- | Renders a jQuery AJAX request definition into Javascript code,
+-- using default settings, and prints it to STDOUT.
+printJSWith
+    :: Settings -- ^ Servant.JQuery Settings
+    -> AjaxReq -- ^ AJAX request definition
+    -> IO ()
+printJSWith settings = putStrLn . generateJSWith settings

--- a/src/Servant/JQuery.hs
+++ b/src/Servant/JQuery.hs
@@ -49,7 +49,6 @@ generateJS' settings req = renderFunctionWrap (_functionFormat settings)
              <> "    , type: '" <> method <> "'\n"
              <> "    });\n"
 
-        argsStr = intercalate ", " args
         args = captures
             ++ map (view argName) queryparams
             ++ body

--- a/src/Servant/JQuery.hs
+++ b/src/Servant/JQuery.hs
@@ -12,10 +12,12 @@
 module Servant.JQuery
   ( jquery
   , generateJS
+  , generateJS'
   , printJS
   , module Servant.JQuery.Internal
-  , Settings
-  , FunctionFormat
+  , Settings(..)
+  , FunctionFormat(..)
+  , defaultSettings
   ) where
 
 import Control.Lens

--- a/src/Servant/JQuery.hs
+++ b/src/Servant/JQuery.hs
@@ -12,7 +12,7 @@
 module Servant.JQuery
   ( jquery
   , generateJS
-  , generateJS'
+  , generateJSWith
   , printJS
   , module Servant.JQuery.Internal
   , Settings(..)
@@ -31,13 +31,18 @@ import Servant.JQuery.Types
 jquery :: HasJQ layout => Proxy layout -> JQ layout
 jquery p = jqueryFor p defReq
 
--- JS codegen with default settings
-generateJS :: AjaxReq -> String
-generateJS = generateJS' defaultSettings
+-- | JS code generation with default settings
+generateJS
+    :: AjaxReq -- ^ AJAX request definition
+    -> String  -- ^ Rendered Javascript
+generateJS = generateJSWith defaultSettings
 
--- JS codegen with custom settings
-generateJS' :: Settings -> AjaxReq -> String
-generateJS' settings req = renderFunctionWrap (_functionFormat settings)
+-- | JS code generation with custom settings
+generateJSWith
+    :: Settings -- ^ Servant.JQuery Settings
+    -> AjaxReq -- ^ AJAX request
+    -> String  -- ^ Rendered Javascript
+generateJSWith settings req = renderFunctionWrap (_functionFormat settings)
                                               fname args inner
   where 
         inner = "  $.ajax(\n"

--- a/src/Servant/JQuery/Functions.hs
+++ b/src/Servant/JQuery/Functions.hs
@@ -45,7 +45,7 @@ hoistedF
 hoistedF fname margs middle = "\n"
     <> "function " <> fname
     <> "(" <> margs <> "){" <> "\n"
-    <> middle <> "}"
+    <> middle <> "}" <> "\n"
 
 -- | Render a non-hoisted function
 nonHoistedF
@@ -57,8 +57,8 @@ nonHoistedF
     -> String -- ^ Rendered JS non-hoisted function
 nonHoistedF mname fname margs middle = "\n"
     <> prefix <> fname <> " = function ("
-    <> margs <> "}{" <> "\n"
-    <> middle <> "};"
+    <> margs <> "){" <> "\n"
+    <> middle <> "};" <> "\n"
   where
     prefix = case mname of
         Just mn -> mn <> "."
@@ -72,7 +72,7 @@ anonF
     -> String -- ^ Rendered JS anonymous function
 anonF margs willReturn middle = "\n"
     <> returnOrNot
-    <> "function(" <> margs
+    <> "function (" <> margs
     <> "){" <> "\n"
     <> middle
     <> returnTrail <> "\n"

--- a/src/Servant/JQuery/Functions.hs
+++ b/src/Servant/JQuery/Functions.hs
@@ -6,7 +6,7 @@ import Data.List
 import Data.Monoid
 import Servant.JQuery.Types
 
--- | Renders a JS function wrapper
+-- | Renders a Javascript function wrapper
 renderFunctionWrap
     :: FunctionFormat -- ^ Format of function
     -> String -- ^ Function name

--- a/src/Servant/JQuery/Functions.hs
+++ b/src/Servant/JQuery/Functions.hs
@@ -1,0 +1,87 @@
+module Servant.JQuery.Functions (
+    renderFunctionWrap
+) where
+
+import Data.List
+import Data.Monoid
+import Servant.JQuery.Types
+
+-- | Renders a JS function wrapper
+renderFunctionWrap
+    :: FunctionFormat -- ^ Format of function
+    -> String -- ^ Function name
+    -> [String] -- ^ Function argument variable names
+    -> String -- ^ Function content
+    -> String -- ^ Rendered JS function
+renderFunctionWrap f n a m = show $ getFunctionWrap f n a (Right m)
+
+-- | Prepares a JS function wrapper
+getFunctionWrap
+    :: FunctionFormat -- ^ Format of function
+    -> String -- ^ Function name
+    -> [String] -- ^ Function argument variable names
+    -> Either JSFunction String -- ^ Function content
+    -> JSFunction -- ^ Prepared JS function
+getFunctionWrap Hoisted n a m     = HoistedFn n a m
+getFunctionWrap NonHoisted n a m  = NonHoistedFn n a Nothing m
+getFunctionWrap (Module mn) n a m = NonHoistedFn n a (Just mn) m
+getFunctionWrap PurescriptFriendly n [] m     = HoistedFn n [] m
+getFunctionWrap PurescriptFriendly n (a:[]) m = HoistedFn n [a] m
+getFunctionWrap PurescriptFriendly n a m = HoistedFn n a . Left $
+    getFunctionWrap (Anonymous True) "" [] m
+getFunctionWrap (Anonymous rt) _ a m = AnonymousFn a rt m
+
+instance Show JSFunction where
+    show (HoistedFn n a m)       = hoistedF n (argsStr a) (either show id m)
+    show (NonHoistedFn n a mn m) = nonHoistedF mn n (argsStr a) (either show id m)
+    show (AnonymousFn a rt m)    = anonF (argsStr a) rt (either show id m)
+
+-- | Renders a hoisted function
+hoistedF
+    :: String -- ^ Function name
+    -> String -- ^ Argument name/s
+    -> String -- ^ Function content
+    -> String -- ^ Rendered JS hoisted function
+hoistedF fname margs middle = "\n"
+    <> "function " <> fname
+    <> "(" <> margs <> "){" <> "\n"
+    <> middle <> "}"
+
+-- | Render a non-hoisted function
+nonHoistedF
+    :: Maybe String -- ^ Either a module name or a Nothing to specify
+                    -- we should use a var
+    -> String -- ^ Function name
+    -> String -- ^ Argument name/s
+    -> String -- ^ Function content
+    -> String -- ^ Rendered JS non-hoisted function
+nonHoistedF mname fname margs middle = "\n"
+    <> prefix <> fname <> " = function ("
+    <> margs <> "}{" <> "\n"
+    <> middle <> "};"
+  where
+    prefix = case mname of
+        Just mn -> mn <> "."
+        Nothing -> "var "
+
+-- | Renders an anonymous function
+anonF
+    :: String -- ^ Argument name/s
+    -> Bool -- ^ Whether the function should be returned as a variable
+    -> String -- ^ Function content
+    -> String -- ^ Rendered JS anonymous function
+anonF margs willReturn middle = "\n"
+    <> returnOrNot
+    <> "function(" <> margs
+    <> "){" <> "\n"
+    <> middle
+    <> returnTrail <> "\n"
+  where
+    returnOrNot = if willReturn then "return " else ""
+    returnTrail = if willReturn then "};" else "}"
+
+-- Turns argument names into a comma separated string
+argsStr
+    :: [String] -- ^ Argument variable names
+    -> String -- ^ Comma separated variable list
+argsStr = intercalate ","

--- a/src/Servant/JQuery/Internal.hs
+++ b/src/Servant/JQuery/Internal.hs
@@ -83,10 +83,16 @@ instance Show HeaderArg where
             T.pack
 
 -- | Attempts to reduce the function name provided to that allowed by JS.
--- https://mathiasbynens.be/notes/javascript-identifiers
--- Couldn't work out how to handle zero-width characters.
+--
+-- See <https://mathiasbynens.be/notes/javascript-identifiers> for more
+-- information on function name encoding.
+--
+-- Note that in this method, we don't currently handle zero-width characters.
+--
 -- @TODO: specify better default function name, or throw error?
-toValidFunctionName :: String -> String
+toValidFunctionName
+  :: String -- ^ Function name to sanitise
+  -> String -- ^ Sanitised function name
 toValidFunctionName (x:xs) = [setFirstChar x] <> filter remainder xs
   where
     setFirstChar c = if firstChar c

--- a/src/Servant/JQuery/Types.hs
+++ b/src/Servant/JQuery/Types.hs
@@ -1,31 +1,59 @@
 module Servant.JQuery.Types where
 
+-- | Defines rendering settings for Javascript functions that contain
+-- jQuery AJAX requests.
 data Settings = Settings
-    { _functionFormat :: FunctionFormat
-    , _baseURI        :: String
+    { _functionFormat :: FunctionFormat -- ^ Format for wrapper function
+    , _baseURI        :: String -- ^ Base URL (yet to be used)
     }
 
+-- | Default settings: hoisted functions, with no base URL.
+--
+-- Equivalent to:
+-- @
+--     Settings Hoisted ""
+-- @
 defaultSettings :: Settings
 defaultSettings = Settings Hoisted ""
 
-data FunctionFormat = Hoisted
-                    | NonHoisted
-                    | Module String
-                    | PurescriptFriendly
-                    | Anonymous Bool
+-- | Selects which format is used to render Javascript functions.
+data FunctionFormat = Hoisted -- ^ Hoisted functions can be invoked in code
+                              -- before they are declared. The function name
+                              -- is 'hoisted' to the top, and invokes the
+                              -- body where it is.
+                    | NonHoisted -- ^ Function declared as a variable, can
+                                 -- only be invoked later in the code.
+                    | Module String -- ^ Function that belongs to an existing
+                                    -- module.
+                                    --
+                                    -- String parameter denotes the
+                                    -- module name.
+                    | PurescriptFriendly -- ^ Function prepared with the right
+                                         --  nesting for Purescript.
+                    | Anonymous Bool -- ^ Anonymous function.
+                                     --
+                                     -- Bool parameter denotes whether the
+                                     -- anonymous function is being returned
+                                     -- as the result of another function.
 
+-- | Internal representation of Javascript functions.
 data JSFunction =
     HoistedFn
-    { _funcName     :: String
-    , _funcArgs     :: [String]
-    , _funcContents :: Either JSFunction String
+    { _funcName     :: String -- ^ Function name
+    , _funcArgs     :: [String] -- ^ Function arguments
+    , _funcContents :: Either JSFunction String -- ^ Function body
     } | NonHoistedFn
-    { _funcName     :: String
-    , _funcArgs     :: [String]
-    , _funcModule   :: Maybe String
-    , _funcContents :: Either JSFunction String
+    { _funcName     :: String -- ^ Function name
+    , _funcArgs     :: [String] -- ^ Function arguments
+    , _funcModule   :: Maybe String -- ^ Name of the module this function is
+                                    -- part of.
+                                    -- 
+                                    -- If Nothing, is treated as a var in the
+                                    -- current scope.
+    , _funcContents :: Either JSFunction String -- ^ Function body
     } | AnonymousFn
-    { _funcArgs     :: [String]
-    , _funcReturned :: Bool
-    , _funcContents :: Either JSFunction String
+    { _funcArgs     :: [String] -- ^ Function arguments
+    , _funcReturned :: Bool -- ^ Whether the function is returned
+                            -- as a variable
+    , _funcContents :: Either JSFunction String -- ^ Function body
     }

--- a/src/Servant/JQuery/Types.hs
+++ b/src/Servant/JQuery/Types.hs
@@ -1,0 +1,31 @@
+module Servant.JQuery.Types where
+
+data Settings = Settings
+    { _functionFormat :: FunctionFormat
+    , _baseURI        :: String
+    }
+
+defaultSettings :: Settings
+defaultSettings = Settings Hoisted ""
+
+data FunctionFormat = Hoisted
+                    | NonHoisted
+                    | Module String
+                    | PurescriptFriendly
+                    | Anonymous Bool
+
+data JSFunction =
+    HoistedFn
+    { _funcName     :: String
+    , _funcArgs     :: [String]
+    , _funcContents :: Either JSFunction String
+    } | NonHoistedFn
+    { _funcName     :: String
+    , _funcArgs     :: [String]
+    , _funcModule   :: Maybe String
+    , _funcContents :: Either JSFunction String
+    } | AnonymousFn
+    { _funcArgs     :: [String]
+    , _funcReturned :: Bool
+    , _funcContents :: Either JSFunction String
+    }

--- a/test/Servant/JQuerySpec.hs
+++ b/test/Servant/JQuerySpec.hs
@@ -15,6 +15,7 @@ import Test.Hspec
 import Servant.API
 import Servant.JQuery
 import Servant.JQuerySpec.CustomHeaders
+import Servant.JQuerySpec.FunctionRender
 
 type TestAPI = [sitemap|
 POST    /simple                  String -> Bool
@@ -49,8 +50,9 @@ customHeaderProxy2 :: Proxy CustomHeaderAPI2
 customHeaderProxy2 = Proxy
 
 spec :: Spec
-spec = describe "Servant.JQuery"
-    generateJSSpec
+spec = do
+    describe "Servant.JQuery" generateJSSpec
+    describe "Servant.JQuery" renderFunctionJSSpec
 
 generateJSSpec :: Spec
 generateJSSpec = describe "generateJS" $ do

--- a/test/Servant/JQuerySpec.hs
+++ b/test/Servant/JQuerySpec.hs
@@ -60,37 +60,31 @@ generateJSSpec = describe "generateJS" $ do
         let (postSimple :<|> getHasExtension ) = jquery (Proxy :: Proxy TestAPI)
         parseFromString (generateJS postSimple) `shouldSatisfy` isRight
         parseFromString (generateJS getHasExtension) `shouldSatisfy` isRight
-        print $ generateJS getHasExtension
 
     it "should use non-empty function names" $ do
         let (_ :<|> topLevel) = jquery (Proxy :: Proxy TopLevelRawAPI)
-        print $ generateJS $ topLevel "GET"
         parseFromString (generateJS $ topLevel "GET") `shouldSatisfy` isRight
 
     it "should handle simple HTTP headers" $ do
         let jsText = generateJS $ jquery headerHandlingProxy
-        print jsText
         parseFromString jsText `shouldSatisfy` isRight
         jsText `shouldContain` "headerFoo"
         jsText `shouldContain` "headers: { \"Foo\": headerFoo }\n"
 
     it "should handle complex HTTP headers" $ do
         let jsText = generateJS $ jquery customAuthProxy
-        print jsText
         parseFromString jsText `shouldSatisfy` isRight
         jsText `shouldContain` "headerAuthorization"
         jsText `shouldContain` "headers: { \"Authorization\": \"Basic \" + headerAuthorization }\n"
 
     it "should handle complex, custom HTTP headers" $ do
         let jsText = generateJS $ jquery customHeaderProxy
-        print jsText
         parseFromString jsText `shouldSatisfy` isRight
         jsText `shouldContain` "headerXMyLovelyHorse"
         jsText `shouldContain` "headers: { \"X-MyLovelyHorse\": \"I am good friends with \" + headerXMyLovelyHorse }\n"
 
     it "should handle complex, custom HTTP headers (template replacement)" $ do
         let jsText = generateJS $ jquery customHeaderProxy2
-        print jsText
         parseFromString jsText `shouldSatisfy` isRight
         jsText `shouldContain` "headerXWhatsForDinner"
         jsText `shouldContain` "headers: { \"X-WhatsForDinner\": \"I would like \" + headerXWhatsForDinner + \" with a cherry on top.\" }\n"

--- a/test/Servant/JQuerySpec/FunctionRender.hs
+++ b/test/Servant/JQuerySpec/FunctionRender.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE QuasiQuotes         #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Servant.JQuerySpec.FunctionRender where
+
+import Data.Either (isRight)
+import Data.List
+import Data.Proxy
+import Language.ECMAScript3.Parser (parseFromString)
+import Test.Hspec
+
+import Servant.API
+import Servant.JQuery
+
+data Book = Book String String
+
+type BookAPI = "books" :> Capture "isbn" String :> Get Book
+
+bookAPIProxy :: Proxy BookAPI
+bookAPIProxy = Proxy
+
+renderFunctionJSSpec :: Spec
+renderFunctionJSSpec = describe "JS function rendering" $ do
+    it "should generate valid javascript with default settings" $ do
+        let out = generateJS' defaultSettings $ jquery bookAPIProxy
+        print out
+        ("\nfunction getbooks(isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
+        ("}\n" `isSuffixOf` out) `shouldBe` True
+        parseFromString out `shouldSatisfy` isRight
+
+    it "should generate valid javascript hoisted function" $ do
+        let out = generateJS' (Settings Hoisted "") $ jquery bookAPIProxy
+        print out
+        ("\nfunction getbooks(isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
+        ("}\n" `isSuffixOf` out) `shouldBe` True
+        parseFromString out `shouldSatisfy` isRight
+
+    it "should generate valid javascript non-hoisted function" $ do
+        let out = generateJS' (Settings NonHoisted "") $ jquery bookAPIProxy
+        print out
+        ("\nvar getbooks = function (isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
+        ("};\n" `isSuffixOf` out) `shouldBe` True
+        parseFromString out `shouldSatisfy` isRight
+
+    it "should generate valid javascript module function" $ do
+        let out = generateJS' (Settings (Module "Foo.Bar") "") $ jquery bookAPIProxy
+        print out
+        ("\nFoo.Bar.getbooks = function (isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
+        ("};\n" `isSuffixOf` out) `shouldBe` True
+        parseFromString out `shouldSatisfy` isRight
+
+    it "should generate valid anonymous function" $ do
+        let out = generateJS' (Settings (Anonymous False) "") $ jquery bookAPIProxy
+        print out
+        ("\nfunction (isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
+        ("}\n" `isSuffixOf` out) `shouldBe` True
+        parseFromString out `shouldSatisfy` isRight
+
+    it "should generate valid anonymous function variable" $ do
+        let out = generateJS' (Settings (Anonymous True) "") $ jquery bookAPIProxy
+        print out
+        ("\nreturn function (isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
+        ("};\n" `isSuffixOf` out) `shouldBe` True
+        parseFromString out `shouldSatisfy` isRight
+
+    it "should generate valid purescript-friendly function" $ do
+        let out = generateJS' (Settings PurescriptFriendly "") $ jquery bookAPIProxy
+        print out
+        ("\nfunction getbooks(isbn,onSuccess,onError){\n\nreturn function (){\n" `isPrefixOf` out) `shouldBe` True
+        ("};\n}\n" `isSuffixOf` out) `shouldBe` True
+        parseFromString out `shouldSatisfy` isRight

--- a/test/Servant/JQuerySpec/FunctionRender.hs
+++ b/test/Servant/JQuerySpec/FunctionRender.hs
@@ -27,43 +27,43 @@ bookAPIProxy = Proxy
 renderFunctionJSSpec :: Spec
 renderFunctionJSSpec = describe "JS function rendering" $ do
     it "should generate valid javascript with default settings" $ do
-        let out = generateJS' defaultSettings $ jquery bookAPIProxy
+        let out = generateJSWith defaultSettings $ jquery bookAPIProxy
         ("\nfunction getbooks(isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
         ("}\n" `isSuffixOf` out) `shouldBe` True
         parseFromString out `shouldSatisfy` isRight
 
     it "should generate valid javascript hoisted function" $ do
-        let out = generateJS' (Settings Hoisted "") $ jquery bookAPIProxy
+        let out = generateJSWith (Settings Hoisted "") $ jquery bookAPIProxy
         ("\nfunction getbooks(isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
         ("}\n" `isSuffixOf` out) `shouldBe` True
         parseFromString out `shouldSatisfy` isRight
 
     it "should generate valid javascript non-hoisted function" $ do
-        let out = generateJS' (Settings NonHoisted "") $ jquery bookAPIProxy
+        let out = generateJSWith (Settings NonHoisted "") $ jquery bookAPIProxy
         ("\nvar getbooks = function (isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
         ("};\n" `isSuffixOf` out) `shouldBe` True
         parseFromString out `shouldSatisfy` isRight
 
     it "should generate valid javascript module function" $ do
-        let out = generateJS' (Settings (Module "Foo.Bar") "") $ jquery bookAPIProxy
+        let out = generateJSWith (Settings (Module "Foo.Bar") "") $ jquery bookAPIProxy
         ("\nFoo.Bar.getbooks = function (isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
         ("};\n" `isSuffixOf` out) `shouldBe` True
         parseFromString out `shouldSatisfy` isRight
 
     it "should generate valid anonymous function" $ do
-        let out = generateJS' (Settings (Anonymous False) "") $ jquery bookAPIProxy
+        let out = generateJSWith (Settings (Anonymous False) "") $ jquery bookAPIProxy
         ("\nfunction (isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
         ("}\n" `isSuffixOf` out) `shouldBe` True
         parseFromString out `shouldSatisfy` isRight
 
     it "should generate valid anonymous function variable" $ do
-        let out = generateJS' (Settings (Anonymous True) "") $ jquery bookAPIProxy
+        let out = generateJSWith (Settings (Anonymous True) "") $ jquery bookAPIProxy
         ("\nreturn function (isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
         ("};\n" `isSuffixOf` out) `shouldBe` True
         parseFromString out `shouldSatisfy` isRight
 
     it "should generate valid purescript-friendly function" $ do
-        let out = generateJS' (Settings PurescriptFriendly "") $ jquery bookAPIProxy
+        let out = generateJSWith (Settings PurescriptFriendly "") $ jquery bookAPIProxy
         ("\nfunction getbooks(isbn,onSuccess,onError){\n\nreturn function (){\n" `isPrefixOf` out) `shouldBe` True
         ("};\n}\n" `isSuffixOf` out) `shouldBe` True
         parseFromString out `shouldSatisfy` isRight

--- a/test/Servant/JQuerySpec/FunctionRender.hs
+++ b/test/Servant/JQuerySpec/FunctionRender.hs
@@ -28,49 +28,42 @@ renderFunctionJSSpec :: Spec
 renderFunctionJSSpec = describe "JS function rendering" $ do
     it "should generate valid javascript with default settings" $ do
         let out = generateJS' defaultSettings $ jquery bookAPIProxy
-        print out
         ("\nfunction getbooks(isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
         ("}\n" `isSuffixOf` out) `shouldBe` True
         parseFromString out `shouldSatisfy` isRight
 
     it "should generate valid javascript hoisted function" $ do
         let out = generateJS' (Settings Hoisted "") $ jquery bookAPIProxy
-        print out
         ("\nfunction getbooks(isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
         ("}\n" `isSuffixOf` out) `shouldBe` True
         parseFromString out `shouldSatisfy` isRight
 
     it "should generate valid javascript non-hoisted function" $ do
         let out = generateJS' (Settings NonHoisted "") $ jquery bookAPIProxy
-        print out
         ("\nvar getbooks = function (isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
         ("};\n" `isSuffixOf` out) `shouldBe` True
         parseFromString out `shouldSatisfy` isRight
 
     it "should generate valid javascript module function" $ do
         let out = generateJS' (Settings (Module "Foo.Bar") "") $ jquery bookAPIProxy
-        print out
         ("\nFoo.Bar.getbooks = function (isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
         ("};\n" `isSuffixOf` out) `shouldBe` True
         parseFromString out `shouldSatisfy` isRight
 
     it "should generate valid anonymous function" $ do
         let out = generateJS' (Settings (Anonymous False) "") $ jquery bookAPIProxy
-        print out
         ("\nfunction (isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
         ("}\n" `isSuffixOf` out) `shouldBe` True
         parseFromString out `shouldSatisfy` isRight
 
     it "should generate valid anonymous function variable" $ do
         let out = generateJS' (Settings (Anonymous True) "") $ jquery bookAPIProxy
-        print out
         ("\nreturn function (isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
         ("};\n" `isSuffixOf` out) `shouldBe` True
         parseFromString out `shouldSatisfy` isRight
 
     it "should generate valid purescript-friendly function" $ do
         let out = generateJS' (Settings PurescriptFriendly "") $ jquery bookAPIProxy
-        print out
         ("\nfunction getbooks(isbn,onSuccess,onError){\n\nreturn function (){\n" `isPrefixOf` out) `shouldBe` True
         ("};\n}\n" `isSuffixOf` out) `shouldBe` True
         parseFromString out `shouldSatisfy` isRight


### PR DESCRIPTION
This is intended to address https://github.com/haskell-servant/servant-jquery/issues/7 by creating a Settings data type which contains a FunctionFormat that dictates how the external wrapper function is rendered.

Currently, the FunctionFormats supported are as follows:
* Hoisted  
  `function foo(arg1, onSuccess, onError){ ... }`
* NonHoisted  
  `var foo = function(arg1, onSuccess, onError){ ... };`
* Module (String - module name)  
  `Hello.World.foo = function(arg1, onSuccess, onError){ ... };`
* PurescriptFriendly  
  `function foo(arg1, onSuccess, onError){ return foo(){ ... }; }`
* Anonymous (Bool - return as a variable)  
  `function(arg1, onSuccess, onError){ ... }` or `return function(arg1, onSuccess, onError){ ... };`

Tests have been added for each one of these FunctionFormats to make sure they render as intended.

(The Settings type also contains a base URL which we don't use yet, but will eventually use to change the URL that the AJAX request is pointed at.)